### PR TITLE
Remove the log message when starting the plugin

### DIFF
--- a/filemanager/init.js
+++ b/filemanager/init.js
@@ -994,8 +994,6 @@ theWebUI.fManager = {
 					table.renameColumnById('type',theUILang.fType);
 					table.renameColumnById('perm',theUILang.fPerm);
 
-					log('FILE MANAGER ignited');
-
 				} else { setTimeout(arguments.callee,500);}
 
 	},


### PR DESCRIPTION
It is unconventional for an ruTorrent plugin to announce its
successful initialization when loading ruTorrent. To my knowledge
no other popular plugin does this, making this plugin a bit of an
anomaly.